### PR TITLE
feat: プラグインカードアクションAPIを追加

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -27,7 +27,7 @@ const {
   uninstallPlugin,
   loadEnabledPlugins,
 } = require('./pluginManager.cjs');
-const { getRegisteredGridLayouts, getRegisteredExportFormats, getExportFormatById } = require('./pluginAPI.cjs');
+const { getRegisteredGridLayouts, getRegisteredExportFormats, getExportFormatById, getRegisteredCardActions, getCardActionById } = require('./pluginAPI.cjs');
 const {
   checkForUpdates,
   downloadUpdate,
@@ -461,6 +461,26 @@ ipcMain.handle('plugins:execute-export-format', async (_, { formatId, logs, boar
     return { success: true, data: content };
   } catch (error) {
     console.error('plugins:execute-export-format error:', error);
+    return { success: false, error: error.message };
+  }
+});
+
+// IPC: カードアクション一覧を取得
+ipcMain.handle('plugins:get-card-actions', () => {
+  return getRegisteredCardActions();
+});
+
+// IPC: カードアクションを実行
+ipcMain.handle('plugins:execute-card-action', async (_, { actionId, cardId, cardData, taskIndex }) => {
+  try {
+    const action = getCardActionById(actionId);
+    if (!action) {
+      return { success: false, error: 'Card action not found' };
+    }
+    const result = action.handler(cardId, cardData, taskIndex);
+    return { success: true, data: result };
+  } catch (error) {
+    console.error('plugins:execute-card-action error:', error);
     return { success: false, error: error.message };
   }
 });

--- a/electron/pluginAPI.cjs
+++ b/electron/pluginAPI.cjs
@@ -10,6 +10,9 @@ const registeredGridLayouts = new Map();
 // 登録されたエクスポートフォーマット
 const registeredExportFormats = new Map();
 
+// 登録されたカードアクション
+const registeredCardActions = new Map();
+
 /**
  * プラグイン用APIを作成
  * @param {string} pluginId - プラグインID
@@ -82,6 +85,39 @@ function createPluginAPI(pluginId, getSettings, saveSettings) {
       const fullId = `${pluginId}:${formatId}`;
       registeredExportFormats.delete(fullId);
       console.log(`[Plugin:${pluginId}] Unregistered export format: ${formatId}`);
+    },
+
+    /**
+     * カードアクションを登録
+     * @param {Object} action - アクション設定
+     * @param {string} action.id - アクションID
+     * @param {string} action.label - ボタンラベル（短いテキストまたは絵文字）
+     * @param {string} [action.title] - ツールチップ
+     * @param {string} action.position - 表示位置: 'task' | 'card-header' | 'card-footer'
+     * @param {function} action.handler - クリック時のハンドラ (cardId, cardData, taskIndex?) => any
+     */
+    registerCardAction(action) {
+      if (!action.id || !action.label || !action.position || typeof action.handler !== 'function') {
+        console.error(`[Plugin:${pluginId}] Invalid card action:`, action);
+        return;
+      }
+      const fullId = `${pluginId}:${action.id}`;
+      registeredCardActions.set(fullId, {
+        ...action,
+        id: fullId,
+        pluginId,
+      });
+      console.log(`[Plugin:${pluginId}] Registered card action: ${action.label} (${action.position})`);
+    },
+
+    /**
+     * カードアクションを登録解除
+     * @param {string} actionId - アクションID
+     */
+    unregisterCardAction(actionId) {
+      const fullId = `${pluginId}:${actionId}`;
+      registeredCardActions.delete(fullId);
+      console.log(`[Plugin:${pluginId}] Unregistered card action: ${actionId}`);
     },
 
     /**
@@ -167,6 +203,35 @@ function clearPluginExportFormats(pluginId) {
   }
 }
 
+/**
+ * 登録済みのカードアクションを全て取得（メタデータのみ）
+ * @returns {Array} カードアクションの配列（handler関数を除く）
+ */
+function getRegisteredCardActions() {
+  return Array.from(registeredCardActions.values()).map(({ handler, ...info }) => info);
+}
+
+/**
+ * IDでカードアクションを取得
+ * @param {string} actionId - アクションID
+ * @returns {Object|undefined} カードアクション（handler関数を含む）
+ */
+function getCardActionById(actionId) {
+  return registeredCardActions.get(actionId);
+}
+
+/**
+ * プラグインのカードアクションを全て削除
+ * @param {string} pluginId - プラグインID
+ */
+function clearPluginCardActions(pluginId) {
+  for (const [key, action] of registeredCardActions) {
+    if (action.pluginId === pluginId) {
+      registeredCardActions.delete(key);
+    }
+  }
+}
+
 module.exports = {
   createPluginAPI,
   getRegisteredGridLayouts,
@@ -174,4 +239,7 @@ module.exports = {
   getRegisteredExportFormats,
   getExportFormatById,
   clearPluginExportFormats,
+  getRegisteredCardActions,
+  getCardActionById,
+  clearPluginCardActions,
 };

--- a/electron/pluginManager.cjs
+++ b/electron/pluginManager.cjs
@@ -8,7 +8,7 @@ const path = require('path');
 const fs = require('fs');
 const https = require('https');
 const { app } = require('electron');
-const { createPluginAPI, clearPluginGridLayouts, clearPluginExportFormats } = require('./pluginAPI.cjs');
+const { createPluginAPI, clearPluginGridLayouts, clearPluginExportFormats, clearPluginCardActions } = require('./pluginAPI.cjs');
 
 // ロード済みプラグインのインスタンス
 const loadedPlugins = new Map();
@@ -349,6 +349,9 @@ function unloadPlugin(pluginId) {
 
     // エクスポートフォーマットをクリア
     clearPluginExportFormats(pluginId);
+
+    // カードアクションをクリア
+    clearPluginCardActions(pluginId);
 
     // ロード済みリストから削除
     loadedPlugins.delete(pluginId);

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -34,6 +34,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getGridLayouts: () => ipcRenderer.invoke('plugins:get-layouts'),
     getExportFormats: () => ipcRenderer.invoke('plugins:get-export-formats'),
     executeExportFormat: (formatId, context) => ipcRenderer.invoke('plugins:execute-export-format', { formatId, ...context }),
+    getCardActions: () => ipcRenderer.invoke('plugins:get-card-actions'),
+    executeCardAction: (actionId, cardId, cardData, taskIndex) => ipcRenderer.invoke('plugins:execute-card-action', { actionId, cardId, cardData, taskIndex }),
   },
   // アップデート関連
   update: {

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -1,6 +1,6 @@
 import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
-import { Column as ColumnType, Card as CardType, CustomSubtag, DefaultSubtagSettings } from '../types';
+import { Column as ColumnType, Card as CardType, CustomSubtag, DefaultSubtagSettings, PluginCardActionInfo } from '../types';
 import { Card } from './Card';
 
 interface ColumnProps {
@@ -17,9 +17,11 @@ interface ColumnProps {
   customSubtags?: CustomSubtag[];
   defaultSubtagSettings?: DefaultSubtagSettings;
   brokenLinkCardIds?: Set<string>;
+  cardActions?: PluginCardActionInfo[];
+  onCardAction?: (cardId: string, actionId: string, taskIndex?: number) => void;
 }
 
-export function Column({ column, cards, onAddCard, onDeleteCard, onEditCard, onJumpCard, onDropWindow, onUpdateDescription, onCardClick, onArchiveCard, customSubtags = [], defaultSubtagSettings, brokenLinkCardIds = new Set() }: ColumnProps) {
+export function Column({ column, cards, onAddCard, onDeleteCard, onEditCard, onJumpCard, onDropWindow, onUpdateDescription, onCardClick, onArchiveCard, customSubtags = [], defaultSubtagSettings, brokenLinkCardIds = new Set(), cardActions = [], onCardAction }: ColumnProps) {
   const { setNodeRef, isOver } = useDroppable({
     id: column.id,
   });
@@ -46,6 +48,8 @@ export function Column({ column, cards, onAddCard, onDeleteCard, onEditCard, onJ
               defaultSubtagSettings={defaultSubtagSettings}
               isBrokenLink={brokenLinkCardIds.has(card.id)}
               columnId={column.id}
+              cardActions={cardActions}
+              onCardAction={(actionId, taskIndex) => onCardAction?.(card.id, actionId, taskIndex)}
             />
           ))}
         </SortableContext>

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -2095,6 +2095,88 @@ body {
   color: #71717a;
 }
 
+/* Task Item with Plugin Actions */
+.task-item-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.task-item-wrapper .task-item {
+  flex: 1;
+}
+
+.task-actions {
+  display: flex;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.task-item-wrapper:hover .task-actions {
+  opacity: 1;
+}
+
+.task-action-btn {
+  padding: 2px 6px;
+  background: rgba(139, 92, 246, 0.2);
+  border: 1px solid rgba(139, 92, 246, 0.3);
+  border-radius: 4px;
+  color: #a78bfa;
+  font-size: 10px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.task-action-btn:hover {
+  background: rgba(139, 92, 246, 0.3);
+  border-color: rgba(139, 92, 246, 0.5);
+}
+
+/* Card Plugin Actions */
+.card-plugin-action {
+  padding: 4px 6px;
+  background: rgba(139, 92, 246, 0.15);
+  border: 1px solid rgba(139, 92, 246, 0.25);
+  border-radius: 4px;
+  color: #a78bfa;
+  font-size: 11px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.card-plugin-action:hover {
+  background: rgba(139, 92, 246, 0.25);
+  border-color: rgba(139, 92, 246, 0.4);
+}
+
+/* Card Footer Actions */
+.card-footer-actions {
+  display: flex;
+  gap: 4px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.card-footer-action-btn {
+  flex: 1;
+  padding: 6px 10px;
+  background: rgba(139, 92, 246, 0.15);
+  border: 1px solid rgba(139, 92, 246, 0.25);
+  border-radius: 4px;
+  color: #a78bfa;
+  font-size: 11px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  text-align: center;
+}
+
+.card-footer-action-btn:hover {
+  background: rgba(139, 92, 246, 0.25);
+  border-color: rgba(139, 92, 246, 0.4);
+}
+
 .card-description-line {
   font-size: 12px;
   color: #a1a1aa;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -221,6 +221,17 @@ export interface PluginExportFormat extends PluginExportFormatInfo {
   generate: (logs: ActivityLog[], boardData: BoardData) => string;
 }
 
+// プラグインカードアクション（レンダラーに送信されるメタデータ）
+export type CardActionPosition = 'task' | 'card-header' | 'card-footer';
+
+export interface PluginCardActionInfo {
+  id: string;           // 例: "timer:start"
+  label: string;        // ボタンラベル（短いテキストまたは絵文字）
+  title?: string;       // ツールチップ
+  position: CardActionPosition;  // 表示位置
+  pluginId: string;     // どのプラグインから来たか
+}
+
 // アップデート関連の型
 export type UpdateStatus = 'idle' | 'checking' | 'available' | 'downloading' | 'downloaded' | 'installing' | 'installed' | 'latest' | 'error';
 
@@ -296,6 +307,8 @@ declare global {
         getGridLayouts: () => Promise<{ success: boolean; data: PluginGridLayout[] }>;
         getExportFormats: () => Promise<{ success: boolean; data: PluginExportFormatInfo[] }>;
         executeExportFormat: (formatId: string, context: { logs: ActivityLog[]; boardData: BoardData }) => Promise<{ success: boolean; data?: string; error?: string }>;
+        getCardActions: () => Promise<PluginCardActionInfo[]>;
+        executeCardAction: (actionId: string, cardId: string, cardData: Card, taskIndex?: number) => Promise<{ success: boolean; data?: unknown; error?: string }>;
       };
       // アップデート関連
       update: {


### PR DESCRIPTION
## Summary
- プラグインからカードやタスクにアクションボタンを追加できるAPIを実装
- timerプラグインなどがUIボタンを追加できるようになります

## 新しいAPI

### プラグイン側
```javascript
api.registerCardAction({
  id: 'my-action',
  label: '⏱',
  title: 'ツールチップ',
  position: 'task',  // 'task' | 'card-header' | 'card-footer'
  handler: (cardId, cardData, taskIndex?) => {
    // アクション実行
  }
});

api.unregisterCardAction('my-action');
```

### 表示位置
| position | 説明 |
|----------|------|
| task | チェックボックスの横（ホバーで表示） |
| card-header | カードヘッダーのアクションボタン群 |
| card-footer | カード下部（独立したボタンエリア） |

## 変更ファイル
- `electron/pluginAPI.cjs` - registerCardAction API追加
- `electron/pluginManager.cjs` - クリーンアップ処理追加
- `electron/main.cjs` - IPCハンドラ追加
- `electron/preload.cjs` - レンダラーにAPI公開
- `src/types/index.ts` - 型定義追加
- `src/components/Card.tsx` - アクションボタン表示
- `src/components/Column.tsx` - propsの伝達
- `src/components/Board.tsx` - アクション取得・実行
- `src/styles/App.css` - スタイル追加

## Test plan
- [ ] プラグインからregisterCardActionでアクションを登録
- [ ] カードヘッダーにボタンが表示される
- [ ] タスクにホバーでボタンが表示される
- [ ] ボタンクリックでhandlerが実行される
- [ ] プラグイン無効化時にアクションが削除される

🤖 Generated with [Claude Code](https://claude.com/claude-code)